### PR TITLE
if the light switch is toggled to off physically, kill the automation

### DIFF
--- a/smartapps/smartthings/gentle-wake-up.groovy
+++ b/smartapps/smartthings/gentle-wake-up.groovy
@@ -130,6 +130,20 @@ private initialize() {
 	subscribe(app, appHandler)
 
 	subscribe(location, locationHandler)
+
+    if (dimmers) {
+        subscribe(dimmers, "switch", switchHandler)
+    }
+}
+
+def switchHandler(evt) {
+    log.debug "switchHandler evt: ${evt.value}"
+    log.debug "switchHandler source: ${evt.source}"
+    log.debug "switchHandler isPhysical(): ${evt.isPhysical()}"
+    if (evt.value == "off" && evt.isPhysical()) {
+        log.debug "Switch was turned off, stopping cycle"
+        completion()
+    }
 }
 
 def appHandler(evt) {


### PR DESCRIPTION
I'm not sure if this is the official place to submit this, I couldn't find proper links to the code anywhere. But here is a small patch to turn off the automation if the light switch is set to off. The current published app will turn off the switch but the cycle doesn't stop so it will turn it back on a few moments later.